### PR TITLE
Two small updates

### DIFF
--- a/sk-cpanel-importer-05.sh
+++ b/sk-cpanel-importer-05.sh
@@ -270,12 +270,14 @@ echo "All mail accounts restored"
 tput setaf 2
 echo "Restoring SSL for domains"
 tput sgr0
-if [ -d ${sk_importer_in}/sslkeys ]; then
-    mv  ${sk_importer_in}/sslkeys/* ${sk_importer_in}/sslcerts/
-    mv  ${sk_importer_in}/ssl/* ${sk_importer_in}/sslcerts/
-   else
-    echo "No SSL folders found"
+
+mv  ${sk_importer_in}/sslkeys/* ${sk_importer_in}/sslcerts/
+if ls -1 ${sk_importer_in}/ssl/* >/dev/null 2>&1; then
+        mv  ${sk_importer_in}/ssl/* ${sk_importer_in}/sslcerts/
+else
+        echo "No SSL Cert. found..."
 fi
+
 
 sk_domains=$(/usr/local/vesta/bin/v-list-web-domains $sk_cp_user plain |awk '{ print  $1 }')
 
@@ -305,16 +307,16 @@ for sk_mx in $sk_domains
 do
 	if [ -e $sk_mx.db ]; then
 		sk_id=$(grep MX /usr/local/vesta/data/users/${sk_cp_user}/dns/${sk_mx}.conf |tr "'" " " | cut -d " " -f 2)
-		v-delete-dns-record $sk_cp_user $sk_mx $sk_id
+		/usr/local/vesta/bin/v-delete-dns-record $sk_cp_user $sk_mx $sk_id
 		grep MX ${sk_mx}.db |  awk '{for(sk=NF;sk>=1;sk--) printf "%s ", $sk;print ""}' | while read value pri ns rest
 			do
 				if [ "$ns" == "MX" ];then
 					if [ "$value" == "$sk_mx" ] || [ "$value" == "$sk_mx." ];then 
 						value=mail.$value
 					fi
-					v-add-dns-record $sk_cp_user $sk_mx @ MX $value $pri
+					/usr/local/vesta/bin/v-add-dns-record $sk_cp_user $sk_mx @ MX $value $pri
 					if [[ "$?" -ge "1" ]]; then
-						v-add-dns-record $sk_cp_user $sk_mx @ MX mail.${sk_mx} 0
+						/usr/local/vesta/bin/v-add-dns-record $sk_cp_user $sk_mx @ MX mail.${sk_mx} 0
 					fi
 					echo "MX fixed in $sk_mx"
 				fi

--- a/sk-cpanel-importer-05.sh
+++ b/sk-cpanel-importer-05.sh
@@ -270,15 +270,20 @@ echo "All mail accounts restored"
 tput setaf 2
 echo "Restoring SSL for domains"
 tput sgr0
-mv  ${sk_importer_in}/sslkeys/* ${sk_importer_in}/sslcerts/
-mv  ${sk_importer_in}/ssl/* ${sk_importer_in}/sslcerts/
-sk_domains=$(v-list-web-domains $sk_cp_user plain |awk '{ print  $1 }')
+if [ -d ${sk_importer_in}/sslkeys ]; then
+    mv  ${sk_importer_in}/sslkeys/* ${sk_importer_in}/sslcerts/
+    mv  ${sk_importer_in}/ssl/* ${sk_importer_in}/sslcerts/
+   else
+    echo "No SSL folders found"
+fi
+
+sk_domains=$(/usr/local/vesta/bin/v-list-web-domains $sk_cp_user plain |awk '{ print  $1 }')
 
 for ssl in $sk_domains
 do
 	if [ -e ${sk_importer_in}/sslcerts/${ssl}.key ]; then
 		echo "Found SSL for ${ssl}, restoring..."
-		v-add-web-domain-ssl $sk_cp_user $ssl ${sk_importer_in}/sslcerts/	 
+		/usr/local/vesta/bin/v-add-web-domain-ssl $sk_cp_user $ssl ${sk_importer_in}/sslcerts/
 	fi
 done
 function sk_restore_pass () {


### PR DESCRIPTION
Fixed two issues I saw during migration.

**1** - Added absolute path "/usr/local/vesta/bin/" for all v- vesta commands, since this path does not get added to user's path during Vesta installation. Also, some sections had the absolute path and some sections did not have it, so to make it consistent and make it more error-free for boxes like mine with no path I added the full path.

**2**- I added folder content check for "${sk_importer_in}/ssl/". If source website did not have SSL cert this folder is empty on default and erroring out with below message.
`mv: cannot stat ‘/root/sk_tmp/backup-1.17.2018_19-32-39_test/ssl/*’: No such file or directory
`
Lines 275 to 279 does check the contents first and if it's empty it skips to avoid errors.