### PR TITLE
Stability

### DIFF
--- a/sk-cpanel-importer-05.sh
+++ b/sk-cpanel-importer-05.sh
@@ -17,6 +17,9 @@ if [ $# -lt 1 ]; then
     echo "usage: bash $0 cpanel-backup.tar.gz MX"
     exit 1
 fi
+if [[ $PATH != *"/usr/local/vesta/bin"* ]];then
+    PATH=$PATH:/usr/local/vesta/bin
+fi
 if [ ! -e /usr/bin/rsync ] || [ ! -e /usr/bin/file ] ; then
 	echo "#######################################"
 	echo "rsync not installed, try install it"
@@ -128,6 +131,7 @@ else
 fi
 
 ### Start with Databases
+mysql -e "SET GLOBAL max_allowed_packet=1073741824;"
 tput setaf 2
 echo "Start with Databases"
 tput sgr0 


### PR DESCRIPTION
If someone just installed Vesta, and didn't log-out and log-in again, and proceeded to this script (Like I would, cuz why loose time?). 
To prevent problems and cleaning of leftovers.

Also to prevent partially imported databases because on CentOS max_allowed_packet defaults to 16M, the value will reset when the server or MySQL restarts ;)