### PR TITLE
BUG FIX - Roundcube can't save sent message

### DIFF
--- a/sk-cpanel-importer-05.sh
+++ b/sk-cpanel-importer-05.sh
@@ -17,7 +17,8 @@ if [ $# -lt 1 ]; then
     echo "usage: bash $0 cpanel-backup.tar.gz MX"
     exit 1
 fi
-if [[ $PATH != *"/usr/local/vesta/bin"* ]];then
+if [[ $PATH != *"/usr/local/vesta/bin"* ]]; then
+    VESTA=/usr/local/vesta
     PATH=$PATH:/usr/local/vesta/bin
 fi
 if [ ! -e /usr/bin/rsync ] || [ ! -e /usr/bin/file ] ; then

--- a/sk-cpanel-importer-05.sh
+++ b/sk-cpanel-importer-05.sh
@@ -266,6 +266,7 @@ if [[ "$sk_maild" != "cur" && "$sk_maild" != "new" && "$sk_maild" != "tmp"  ]]; 
 					/usr/local/vesta/bin/v-add-mail-account $sk_cp_user $sk_maild $sk_mail_account $sk_mail_pass1
 					mv ${sk_maild}/${sk_mail_account} /home/${sk_cp_user}/mail/${sk_maild}
 					chown ${sk_cp_user}:mail -R /home/${sk_cp_user}/mail/${sk_maild}
+					find /home/${sk_cp_user}/mail/${sk_maild} -type f -name 'dovecot*' -delete
 					echo "${sk_mail_account}@${sk_maild} | $sk_mail_pass1"	>> /root/sk_mail_password_${sk_cp_user}-${sk_cod}
 		done
 	fi


### PR DESCRIPTION
> IMAP Error: Could not save message in Sent


This fixes the bug in Roundcube when there are no messages in Sent folder or when sent messages are not being saved to Sent folder. This happens if Dovecot versions between old and new server are different. Happened to me multiple times. :)
This fixes it

It was also resulting in dovecot being restarted each time user attempts to send a message because it couldn't be saved to Sent folder..

> Error: Raw backtrace: /usr/lib64/dovecot/libdovecot.so.0(+0x6a06e) [0x7fb1c1cc706e] -> /usr/lib64/dovecot/libdovecot.so.0(+0x6a14e) [0x7fb1c1cc714e] -> /usr/lib64/dovecot/libdovecot.so.0(i_fatal+0) [0x7fb1c1c7f52c] -> /usr/lib64/dovecot/libdovecot-storage.so.0(mail_index_sync_keywords+0x808) [0x7fb1c1ffe5c8] -> /usr/lib64/dovecot/libdovecot-storage.so.0(mail_index_sync_record+0xfd) [0x7fb1c1ffeeed] -> /usr/lib64/dovecot/libdovecot-storage.so.0(mail_index_sync_map+0x21e) [0x7fb1c1fffe8e] -> /usr/lib64/dovecot/libdovecot-storage.so.0(mail_index_map+0x3e7) [0x7fb1c1ff0b77] -> /usr/lib64/dovecot/libdovecot-storage.so.0(+0xb937d) [0x7fb1c1fec37d] -> /usr/lib64/dovecot/libdovecot-storage.so.0(+0xb9990) [0x7fb1c1fec990] -> /usr/lib64/dovecot/libdovecot-storage.so.0(mail_index_open+0x8c) [0x7fb1c1feca7c] -> /usr/lib64/dovecot/libdovecot-storage.so.0(index_storage_mailbox_open+0x87) [0x7fb1c1fdd9c7] -> /usr/lib64/dovecot/libdovecot-storage.so.0(+0x4d882) [0x7fb1c1f80882] -> /usr/lib64/dovecot/libdovecot-storage.so.0(+0x4d963) [0x7fb1c1f80963] -> /usr/lib64/dovecot/libdovecot-storage.so.0(+0x802b4) [0x7fb1c1fb32b4] -> /usr/lib64/dovecot/libdovecot-storage.so.0(mailbox_open+0x20) [0x7fb1c1fb3430] -> dovecot/imap(client_open_save_dest_box+0x86) [0x563a63858636] -> dovecot/imap(cmd_append+0xa7) [0x563a6384ca77] -> dovecot/imap(command_exec+0x3c) [0x563a6385801c] -> dovecot/imap(+0x17f1f) [0x563a63856f1f] -> dovecot/imap(+0x18005) [0x563a63857005] -> dovecot/imap(client_handle_input+0x14d) [0x563a638572fd] -> dovecot/imap(client_input+0x85) [0x563a638576c5] -> /usr/lib64/dovecot/libdovecot.so.0(io_loop_call_io+0x27) [0x7fb1c1cd7a87] -> /usr/lib64/dovecot/libdovecot.so.0(io_loop_handler_run+0xff) [0x7fb1c1cd890f] -> /usr/lib64/dovecot/libdovecot.so.0(io_loop_run+0x38) [0x7fb1c1cd75d8] -> /usr/lib64/dovecot/libdovecot.so.0(master_service_run+0x13) [0x7fb1c1c849e3] -> dovecot/imap(main+0x2c4) [0x563a6384b324] -> /lib64/libc.so.6(__libc_start_main+0xf5) [0x7fb1c18bbc05]

